### PR TITLE
fix: update dependencies to Render-compatible versions

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
-fastapi==0.104.1
-uvicorn==0.24.0
-requests==2.31.0
-python-dotenv==1.0.0
-pydantic==2.5.0
-python-multipart==0.0.6 
+fastapi==0.115.6
+uvicorn[standard]==0.32.1
+requests==2.32.3
+python-dotenv==1.0.1
+pydantic==2.10.4
+python-multipart==0.0.20 


### PR DESCRIPTION
- Update pydantic to 2.10.4 (has pre-compiled wheels)
- Update fastapi to 0.115.6 for better compatibility
- Update uvicorn to 0.32.1 with standard extras
- Update other dependencies to latest stable versions
- Resolves Rust compilation issues on Render