### PR TITLE
fix: resolve double prefix issue in leadership router

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -18,8 +18,8 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Include routers
-app.include_router(leadership.router, prefix="/leadership", tags=["leadership"])
+# Include routers (prefix is already defined in the router)
+app.include_router(leadership.router)
 
 @app.get("/")
 async def root():


### PR DESCRIPTION
- Remove duplicate '/leadership' prefix in main.py router include
- Router already defines prefix in leadership.py
- Fixes 404 errors for /leadership/health and /leadership/addTags
- Resolves Google Apps Script connection issues