### PR TITLE
Fix/version management workflow

### DIFF
--- a/.github/workflows/backend-version-increment.yml
+++ b/.github/workflows/backend-version-increment.yml
@@ -46,7 +46,7 @@ jobs:
       id: check_merge
       run: |
         # Check if this is a merge commit (has 2+ parents)
-        PARENT_COUNT=$(git rev-list --count --parents -n 1 HEAD | awk '{print NF-1}')
+        PARENT_COUNT=$(git rev-list --parents -n 1 HEAD | awk '{print NF-1}')
         if [ $PARENT_COUNT -gt 1 ]; then
           echo "is_merge=true" >> $GITHUB_OUTPUT
           echo "📝 This is a merge commit - will update version"

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the BARS backend will be documented in this file.
 
+## [2.0.0] - 2025-07-15
+
+### 🔧 Other Changes
+- c426d9f Merge pull request #17 from barswebadmin/update-main-py-again
+- 7dd1a06 Fix Slack webhook invalid_blocks error and add comprehensive test suite
+- 0beb17c update Makefile for CI checks
+- 345b19b Merge pull request #11 from barswebadmin/backend-production-ready
+- c071343 Merge pull request #13 from barswebadmin/fix-render-yaml
+- 4555b86 Fix double parentheses in refund calculation messages
+- cf05b4f fix tests again to pass CI checks
+- 50de248 Merge pull request #10 from barswebadmin/update-lambda-logic
+- b04259f Merge pull request #12 from barswebadmin/backend-production-ready-2
+- 6c7cd90 Merge pull request #15 from barswebadmin/test-auto-deploy
+
+### 📁 Files Changed
+- `backend/.env.example`
+- `backend/Makefile`
+- `backend/ORDERS_API_README.md`
+- `backend/PRODUCTION_DEPLOYMENT.md`
+- `backend/REFACTORING_SUMMARY.md`
+- `backend/SLACK_TESTING_README.md`
+- `backend/SLACK_WEBHOOK_TESTING.md`
+- `backend/TESTING_GUIDE.md`
+- `backend/config.py`
+- `backend/env.example`
+- ... and 37 more files
+
+
+
+All notable changes to the BARS backend will be documented in this file.
+
 ## [1.0.3] - 2025-06-26
 
 ### 🐛 Bug Fixes

--- a/backend/version.py
+++ b/backend/version.py
@@ -1,7 +1,7 @@
 # Backend Version Management
 # This file tracks the current version of the BARS backend API
 
-__version__ = "1.0.3"
+__version__ = "2.0.0"
 __build__ = 4
 __last_updated__ = "2025-06-26"
 __codename__ = "Render Ready"

--- a/backend/version.py
+++ b/backend/version.py
@@ -1,9 +1,9 @@
 # Backend Version Management
 # This file tracks the current version of the BARS backend API
 
-__version__ = "2.0.0"
-__build__ = 1
-__last_updated__ = "2025-07-15"
+__version__ = "1.0.3"
+__build__ = 4
+__last_updated__ = "2025-06-26"
 __codename__ = "Render Ready"
 
 # Version history for reference

--- a/backend/version.py
+++ b/backend/version.py
@@ -1,9 +1,9 @@
 # Backend Version Management
 # This file tracks the current version of the BARS backend API
 
-__version__ = "1.0.3"
-__build__ = 4
-__last_updated__ = "2025-06-26"
+__version__ = "2.0.0"
+__build__ = 1
+__last_updated__ = "2025-07-15"
 __codename__ = "Render Ready"
 
 # Version history for reference


### PR DESCRIPTION
removed `--count` flag from check so merges will actually increment the version now. auto-updated to `2.0.0` because last pr was a huge change