### PR TITLE
fix: Remove invalid Lambda layer reference from deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,13 +102,12 @@ jobs:
                       zip -r "../${func_dir}.zip" .
                       cd ..
 
-                      # Update function configuration with layer and version in description
+                      # Update function configuration with version in description
                       echo "Updating function configuration for $func_dir..."
                       DESCRIPTION="Version ${VERSION} - Updated $(date '+%Y-%m-%d %H:%M:%S')"
                       aws lambda update-function-configuration \
                         --function-name "$func_dir" \
-                        --description "$DESCRIPTION" \
-                        --layers "$LAYER_VERSION"
+                        --description "$DESCRIPTION"
 
                       # Wait for update to complete
                       echo "Waiting for function configuration update to complete..."


### PR DESCRIPTION
• Remove --layers parameter from aws lambda update-function-configuration • The bars-common-utils layer deployment is commented out, causing empty LAYER_VERSION • Lambda functions now use self-contained deployments with copied shared utilities • Fixes deployment error: 'Invalid length for parameter Layers[0], value: 0'

The functions still work correctly without the layer since they include fallback implementations and copied shared utilities.