### PR TITLE
🔒 Fix TLS Certificate Bundle Issues in Render Deployment

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,16 @@
+# CRITICAL: Configure SSL certificates BEFORE any other imports
+import os
+
+if os.getenv("ENVIRONMENT") == "production":
+    # Force SSL certificate paths for Render (Ubuntu) deployment
+    os.environ["SSL_CERT_FILE"] = "/etc/ssl/certs/ca-certificates.crt"
+    os.environ["REQUESTS_CA_BUNDLE"] = "/etc/ssl/certs/ca-certificates.crt"
+    os.environ["CURL_CA_BUNDLE"] = "/etc/ssl/certs/ca-certificates.crt"
+    # Clear any existing SSL environment variables that might point to wrong paths
+    for env_var in ["SSL_CERT_DIR", "OPENSSL_CONF"]:
+        if env_var in os.environ:
+            del os.environ[env_var]
+
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from routers import leadership, orders, refunds, slack, webhooks

--- a/backend/services/shopify/shopify_service.py
+++ b/backend/services/shopify/shopify_service.py
@@ -95,12 +95,19 @@ class ShopifyService:
         logger.info(f"🔒 REQUESTS_CA_BUNDLE: {os.getenv('REQUESTS_CA_BUNDLE')}")
 
         try:
+            # Use explicit SSL certificate bundle for production
+            cert_bundle = (
+                "/etc/ssl/certs/ca-certificates.crt"
+                if os.getenv("ENVIRONMENT") == "production"
+                else True
+            )
+
             response = requests.post(
                 self.graphql_url,
                 headers=self.headers,
                 json=query,
                 timeout=30,
-                verify=True,  # Explicitly enable SSL verification
+                verify=cert_bundle,  # Use explicit certificate bundle
             )
             logger.info(f"📥 Response status: {response.status_code}")
 

--- a/backend/services/slack/api_client.py
+++ b/backend/services/slack/api_client.py
@@ -245,19 +245,25 @@ class SlackApiClient:
             logger.info(f"Sending Slack message to channel {self.channel_id}")
             logger.debug(f"Message content: {message_text[:100]}...")
 
-            # Send the request
+            # Send the request with explicit SSL certificate bundle
+            cert_bundle = (
+                "/etc/ssl/certs/ca-certificates.crt"
+                if os.getenv("ENVIRONMENT") == "production"
+                else True
+            )
+
             try:
                 response = requests.post(
-                    url, headers=headers, data=json.dumps(payload), verify=True
+                    url, headers=headers, data=json.dumps(payload), verify=cert_bundle
                 )
                 response_data = response.json()
             except requests.exceptions.SSLError as ssl_error:
                 logger.warning(
-                    f"SSL Error with Slack API - trying without verification: {ssl_error}"
+                    f"SSL Error with Slack API - trying with system default: {ssl_error}"
                 )
-                # Fallback: try without SSL verification (for development)
+                # Fallback: try with system default SSL verification
                 response = requests.post(
-                    url, headers=headers, data=json.dumps(payload), verify=False
+                    url, headers=headers, data=json.dumps(payload), verify=True
                 )
                 response_data = response.json()
 
@@ -342,18 +348,25 @@ class SlackApiClient:
             # Log message update attempt
             print(f"📤 Sending message update to Slack channel {self.channel_id}")
 
+            # Use explicit SSL certificate bundle
+            cert_bundle = (
+                "/etc/ssl/certs/ca-certificates.crt"
+                if os.getenv("ENVIRONMENT") == "production"
+                else True
+            )
+
             try:
                 response = requests.post(
-                    url, headers=headers, data=json.dumps(payload), verify=True
+                    url, headers=headers, data=json.dumps(payload), verify=cert_bundle
                 )
                 response_data = response.json()
             except requests.exceptions.SSLError as ssl_error:
                 logger.warning(
-                    f"SSL Error with Slack API update - trying without verification: {ssl_error}"
+                    f"SSL Error with Slack API update - trying with system default: {ssl_error}"
                 )
-                # Fallback: try without SSL verification (for development)
+                # Fallback: try with system default SSL verification
                 response = requests.post(
-                    url, headers=headers, data=json.dumps(payload), verify=False
+                    url, headers=headers, data=json.dumps(payload), verify=True
                 )
                 response_data = response.json()
 
@@ -413,8 +426,18 @@ class SlackApiClient:
                 f"Ephemeral message content: {request_payload['text'][:100]}..."
             )
 
+            # Use explicit SSL certificate bundle
+            cert_bundle = (
+                "/etc/ssl/certs/ca-certificates.crt"
+                if os.getenv("ENVIRONMENT") == "production"
+                else True
+            )
+
             response = requests.post(
-                url, headers=headers, data=json.dumps(request_payload)
+                url,
+                headers=headers,
+                data=json.dumps(request_payload),
+                verify=cert_bundle,
             )
             response_data = response.json()
 
@@ -470,19 +493,25 @@ class SlackApiClient:
                 f"Modal content: {modal_view.get('title', {}).get('text', 'Unknown title')}"
             )
 
-            # Send the request with SSL verification fallback
+            # Send the request with explicit SSL certificate bundle
+            cert_bundle = (
+                "/etc/ssl/certs/ca-certificates.crt"
+                if os.getenv("ENVIRONMENT") == "production"
+                else True
+            )
+
             try:
                 response = requests.post(
-                    url, headers=headers, data=json.dumps(payload), verify=True
+                    url, headers=headers, data=json.dumps(payload), verify=cert_bundle
                 )
                 response_data = response.json()
             except requests.exceptions.SSLError as ssl_error:
                 logger.warning(
-                    f"SSL Error with Slack API - trying without verification: {ssl_error}"
+                    f"SSL Error with Slack API - trying with system default: {ssl_error}"
                 )
-                # Fallback: try without SSL verification (for development)
+                # Fallback: try with system default SSL verification
                 response = requests.post(
-                    url, headers=headers, data=json.dumps(payload), verify=False
+                    url, headers=headers, data=json.dumps(payload), verify=True
                 )
                 response_data = response.json()
 


### PR DESCRIPTION
## 🚨 **Critical SSL Fix for Production**

### **Problem**
Production Slack API calls were failing with TLS certificate errors:
```
❌ Modal result: {'success': False, 'error': 'Slack API error: Unexpected error: Could not find a suitable TLS CA certificate bundle, invalid path: /opt/homebrew/etc/openssl@3/cert.pem'}
```

### **Root Cause**
- System was trying to use **macOS Homebrew SSL paths** even in **Render (Ubuntu)** environment
- SSL environment variables weren't set early enough in application lifecycle
- Requests library was using default SSL verification instead of explicit certificate bundle

### **Comprehensive Solution**

#### 🏗️ **1. Early SSL Configuration (main.py)**
- Set SSL environment variables **BEFORE any other imports**
- Clear conflicting SSL environment variables (`SSL_CERT_DIR`, `OPENSSL_CONF`)
- Force Ubuntu SSL paths in production environment

#### 🔧 **2. Explicit Certificate Bundle in All HTTP Requests**
Updated **6 locations** across services:
- ✅ Slack API client (5 requests.post calls)
- ✅ Shopify service (1 requests.post call)
- Uses `/etc/ssl/certs/ca-certificates.crt` explicitly in production
- Maintains `verify=True` for development environments

#### 🛡️ **3. Improved Error Handling**
- Better fallback to system default SSL verification
- Clearer SSL error logging
- **Never disables SSL verification** (maintains security)

### **Benefits**
✅ **Eliminates TLS certificate bundle errors** in Render deployment  
✅ **Maintains SSL security** with proper certificate verification  
✅ **Works in both environments** - development (macOS) and production (Ubuntu)  
✅ **Graceful error handling** with intelligent fallbacks  
✅ **Early configuration** prevents SSL issues during app startup  

### **Testing**
- [x] Code formatting passes (ruff, pre-commit hooks)
- [x] No breaking changes to existing functionality
- [x] SSL configuration is environment-aware
- [ ] **Needs testing**: Deploy to Render and test Slack modal interactions

### **Files Changed**
- `backend/main.py` - Early SSL environment configuration
- `backend/services/slack/api_client.py` - Explicit certificate bundle in 5 locations
- `backend/services/shopify/shopify_service.py` - Explicit certificate bundle

### **Urgency: HIGH** 🚨
This fixes critical production functionality - Slack refund request modals are currently broken due to SSL errors.

**Ready for immediate merge and deployment to resolve production issues.**