### PR TITLE
remove: GitHub workflow concurrency prevention across all workflows

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,9 +1,5 @@
 name: Backend Tests
 
-# Prevent duplicate runs for the same branch/PR
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
 
 on:
   push:

--- a/.github/workflows/backend-version-increment.yml
+++ b/.github/workflows/backend-version-increment.yml
@@ -17,10 +17,6 @@ on:
       - '!backend/CHANGELOG.md'
   workflow_dispatch:
 
-# Prevent duplicate runs: cancel in-progress runs when new commits are pushed
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
 
 jobs:
   update-version:

--- a/.github/workflows/compilation-check.yml
+++ b/.github/workflows/compilation-check.yml
@@ -7,10 +7,6 @@ on:
     branches: [ main ]
     types: [opened, synchronize, reopened]
 
-# Prevent duplicate runs: use branch name for consistency across push/PR events
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
 
 jobs:
   compilation-check:

--- a/.github/workflows/deploy-render.yml
+++ b/.github/workflows/deploy-render.yml
@@ -1,9 +1,5 @@
 name: Deploy to Render
 
-# Prevent duplicate runs for the same branch/PR
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-to-render.yml
+++ b/.github/workflows/deploy-to-render.yml
@@ -1,9 +1,5 @@
 name: Deploy to Render
 
-# Prevent duplicate runs: use branch name for consistency across push/PR events
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
 
 on:
   push:

--- a/.github/workflows/google-apps-scripts-tests.yml
+++ b/.github/workflows/google-apps-scripts-tests.yml
@@ -1,10 +1,6 @@
 name: Google Apps Scripts Tests
 
 
-# Prevent duplicate runs for the same branch/PR
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/lambda-version-increment.yml
+++ b/.github/workflows/lambda-version-increment.yml
@@ -15,10 +15,6 @@ on:
       - '!lambda-functions/**/version.py'
   workflow_dispatch:
 
-# Prevent duplicate runs: cancel in-progress runs when new commits are pushed
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
 
 jobs:
   increment-versions:

--- a/.github/workflows/validate-changes.yml
+++ b/.github/workflows/validate-changes.yml
@@ -1,9 +1,5 @@
 name: Validate Changes (No Deploy)
 
-# Prevent duplicate runs: use branch name for consistency across push/PR events
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
 
 on:
   push:


### PR DESCRIPTION
## 🚀 Remove Workflow Concurrency Prevention

This PR removes concurrency prevention blocks from all GitHub workflow files to allow multiple workflow runs to execute simultaneously without cancellation.

### 🎯 **What Changed**
- Removed `concurrency:` blocks from 8 workflow files
- Eliminated `cancel-in-progress: true` settings
- Removed workflow grouping that prevented parallel execution

### 📋 **Affected Workflows**
- `backend-tests.yml`
- `backend-version-increment.yml` 
- `compilation-check.yml`
- `deploy-render.yml`
- `deploy-to-render.yml`
- `google-apps-scripts-tests.yml`
- `lambda-version-increment.yml`
- `validate-changes.yml`

### 🔄 **Impact**
- **Before**: New commits would cancel running workflows
- **After**: Multiple workflows can run simultaneously
- **Deployment**: `deploy-to-render.yml` will still run once per merge to main (no duplication)

### ✅ **Benefits**
- Faster CI/CD pipeline execution
- No interrupted test runs
- Better resource utilization
- Parallel processing of different workflow types

### 🎯 **Testing**
- All workflows validated for YAML syntax
- Pre-commit hooks passed
- Ready for immediate deployment

This change will improve CI/CD performance by allowing workflows to run in parallel rather than being cancelled and restarted.