### PR TITLE
Generate test json for scheduled product changes

### DIFF
--- a/backend/services/products/schedule-product-updates-tests/add-inventory-to-live-product.json
+++ b/backend/services/products/schedule-product-updates-tests/add-inventory-to-live-product.json
@@ -1,0 +1,16 @@
+{
+  "actionType": "add-inventory-to-live-product",
+  "sport": "Kickball",
+  "day": "Monday",
+  "division": "Social",
+  "scheduleName": "auto-add-remaining-inventory-123456789-kb-monday-socialdiv",
+  "groupName": "add-remaining-inventory-to-live-product",
+  "productUrl": "https://09fe59-3.myshopify.com/admin/products/123456789",
+  "productTitle": "Big Apple Kickball - Monday - Social Division - Spring 2025",
+  "variantGid": "gid://shopify/ProductVariant/222222222",
+  "newDatetime": "2025-01-15T14:00:00",
+  "note": "newDatetime is UTC; ET is earlier",
+  "inventoryToAdd": 60,
+  "totalInventory": 100,
+  "numberVetSpotsToReleaseAtGoLive": 40
+}

--- a/backend/services/products/schedule-product-updates-tests/create-initial-inventory-addition-and-title-change.json
+++ b/backend/services/products/schedule-product-updates-tests/create-initial-inventory-addition-and-title-change.json
@@ -1,0 +1,15 @@
+{
+  "actionType": "create-initial-inventory-addition-and-title-change",
+  "sport": "Kickball",
+  "day": "Monday",
+  "division": "Social",
+  "scheduleName": "auto-set-123456789-kb-monday-socialdiv-live",
+  "groupName": "set-product-live",
+  "productUrl": "https://09fe59-3.myshopify.com/admin/products/123456789",
+  "productTitle": "Big Apple Kickball - Monday - Social Division - Spring 2025",
+  "variantGid": "gid://shopify/ProductVariant/111111111",
+  "newDatetime": "2025-01-10T14:00:00",
+  "note": "newDatetime is UTC; ET is earlier",
+  "totalInventory": 100,
+  "numberVetSpotsToReleaseAtGoLive": 40
+}

--- a/backend/services/products/schedule-product-updates-tests/create-scheduled-inventory-movements.json
+++ b/backend/services/products/schedule-product-updates-tests/create-scheduled-inventory-movements.json
@@ -1,0 +1,23 @@
+{
+  "actionType": "create-scheduled-inventory-movements",
+  "sport": "Kickball",
+  "day": "Monday",
+  "division": "Social",
+  "scheduleName": "auto-move-123456789-kb-monday-vet-to-early",
+  "groupName": "move-inventory-between-variants-kb",
+  "productUrl": "https://09fe59-3.myshopify.com/admin/products/123456789",
+  "sourceVariant": {
+    "type": "vet",
+    "name": "Vet Registration",
+    "gid": "gid://shopify/ProductVariant/111111111"
+  },
+  "destinationVariant": {
+    "type": "early",
+    "name": "Early Registration",
+    "gid": "gid://shopify/ProductVariant/222222222"
+  },
+  "newDatetime": "2025-01-15T14:00:00",
+  "note": "newDatetime is UTC; ET is earlier",
+  "totalInventory": 100,
+  "numberVetSpotsToReleaseAtGoLive": 40
+}

--- a/backend/services/products/schedule-product-updates-tests/create-scheduled-price-changes.json
+++ b/backend/services/products/schedule-product-updates-tests/create-scheduled-price-changes.json
@@ -1,0 +1,14 @@
+{
+  "actionType": "create-scheduled-price-changes",
+  "sport": "Kickball",
+  "day": "Monday",
+  "division": "Social",
+  "productGid": "gid://shopify/Product/123456789",
+  "productUrl": "https://09fe59-3.myshopify.com/admin/products/123456789",
+  "openVariantGid": "gid://shopify/ProductVariant/333333333",
+  "waitlistVariantGid": "gid://shopify/ProductVariant/444444444",
+  "price": 115,
+  "seasonStartDate": "2025-02-03",
+  "sportStartTime": "21:00:00",
+  "offDatesCommaSeparated": "2025-02-17,2025-03-24"
+}


### PR DESCRIPTION
Add JSON test request bodies for `ScheduleChangesForShopifyProductsLambda` to facilitate backend testing.

---
[Slack Thread](https://bigapplerec.slack.com/archives/D09FD2DEN3Y/p1757984057368189?thread_ts=1757984057.368189&cid=D09FD2DEN3Y)

<a href="https://cursor.com/background-agent?bcId=bc-acf95332-0c59-4977-b6d1-16a8b7429387">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-acf95332-0c59-4977-b6d1-16a8b7429387">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

