### PR TITLE
CI(GAS): add ESLint no-undef lint to catch undefined identifiers

### DIFF
--- a/.github/workflows/compilation-check.yml
+++ b/.github/workflows/compilation-check.yml
@@ -143,6 +143,25 @@ jobs:
         console.log('✅ Google Apps Scripts compilation successful!');
         "
 
+        # Lint for undefined identifiers using ESLint (no-undef)
+        echo "🔍 Linting GAS files for undefined identifiers (no-undef)..."
+        npm init -y >/dev/null 2>&1 || true
+        npm install --no-fund --no-audit --silent eslint@8
+        # Collect all .gs files under projects/*/src
+        FILES=$(find projects -type f -path '*/src/*' -name '*.gs')
+        if [ -n "$FILES" ]; then
+          npx eslint \
+            --no-eslintrc \
+            --ext .gs \
+            --rule 'no-undef:error' \
+            --env es6 \
+            --global 'Logger:false,UrlFetchApp:false,PropertiesService:false,Utilities:false,SpreadsheetApp:false,DriveApp:false,Session:false,FormApp:false,HtmlService:false,ContentService:false,ScriptApp:false,GmailApp:false' \
+            $FILES || { echo '❌ GAS no-undef check failed'; exit 1; }
+        else
+          echo "ℹ️ No GAS source files found to lint"
+        fi
+        echo "✅ GAS no-undef check passed"
+
         echo "success=true" >> $GITHUB_OUTPUT
         echo "✅ Google Apps Scripts compilation check passed"
 


### PR DESCRIPTION
- Add ESLint no-undef pass for Apps Script sources during compilation-check\n- Fails on undefined references (e.g., isDebug) while keeping existing syntax checks\n- Uses minimal globals allowlist for Apps Script runtime