### PR TITLE
fix(ci): point Lambda workflows and scripts at aws/lambda

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -5,7 +5,7 @@ on:
   # push:
   #   branches: [ main ]
   #   paths:
-  #     - 'lambda/functions/**'
+  #     - 'aws/lambda/**'
   #     - '.github/workflows/deploy-aws.yml'
 
   workflow_dispatch:
@@ -29,7 +29,7 @@ on:
 #   pull_request:
 #     branches: [main]
 #     paths:
-#       - 'lambda/functions/**'
+#       - 'aws/lambda/**'
 #     types: [opened, synchronize, reopened]
 
 jobs:
@@ -64,6 +64,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
+          ignore-nothing-to-cache: true
 
       - name: Set up AWS CLI
         uses: aws-actions/configure-aws-credentials@v4
@@ -80,11 +81,11 @@ jobs:
             FUNCTION_INPUT="${{ github.event.inputs.function }}"
             if [ "$FUNCTION_INPUT" == "all" ] || [ -z "$FUNCTION_INPUT" ]; then
               echo "📦 Manual deployment: all functions"
-              CHANGED=$(find lambda/functions -maxdepth 1 -type d -not -name "functions" -not -name "tests" -not -name "SyncSecretsToLambda" | sed 's|lambda/functions/||' | sort)
+              CHANGED=$(find aws/lambda/functions -mindepth 1 -maxdepth 1 -type d ! -name tests | sed 's|aws/lambda/functions/||' | sort)
             else
               echo "📦 Manual deployment: $FUNCTION_INPUT"
               # Validate function exists
-              if [ ! -d "lambda/functions/$FUNCTION_INPUT" ]; then
+              if [ ! -d "aws/lambda/functions/$FUNCTION_INPUT" ]; then
                 echo "❌ Function $FUNCTION_INPUT not found"
                 echo "has_changes=false" >> $GITHUB_OUTPUT
                 exit 1
@@ -93,7 +94,7 @@ jobs:
             fi
           else
             # Automatic trigger: only deploy changed functions
-            CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} -- lambda/functions/ | grep -E '^lambda/functions/[^/]+/' | cut -d/ -f3 | sort -u)
+            CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} -- aws/lambda/functions/ | grep -E '^aws/lambda/functions/[^/]+/' | cut -d/ -f4 | sort -u)
           fi
           
           if [ -z "$CHANGED" ]; then

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -65,6 +65,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
+          ignore-nothing-to-cache: true
 
       - name: Install Python dependencies
         run: python scripts/ci/install_dependencies.py deploy

--- a/.github/workflows/deploy-google.yml
+++ b/.github/workflows/deploy-google.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 10.16.0
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/test-aws.yml
+++ b/.github/workflows/test-aws.yml
@@ -4,12 +4,12 @@ on:
   push:
     branches: [main]
     paths:
-      - 'lambda/functions/**'
+      - 'aws/lambda/**'
       - '.github/workflows/test-aws.yml'
   pull_request:
     branches: [main]
     paths:
-      - 'lambda/functions/**'
+      - 'aws/lambda/**'
       - '.github/workflows/test-aws.yml'
     types: [opened, synchronize, reopened]
 
@@ -42,6 +42,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
+          ignore-nothing-to-cache: true
 
       - name: Install dependencies
         run: python scripts/ci/install_dependencies.py lambda
@@ -52,4 +53,4 @@ jobs:
 
       - name: Run Lambda tests
         if: steps.compile.outcome == 'success'
-        run: python lambda/functions/tests/run_tests.py
+        run: pytest aws/lambda/tests -q

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -45,6 +45,8 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
+          # Root uv.lock is gitignored; cache glob would otherwise fail the step.
+          ignore-nothing-to-cache: true
 
       - name: Install dependencies
         run: python scripts/ci/install_dependencies.py backend

--- a/.github/workflows/test-google.yml
+++ b/.github/workflows/test-google.yml
@@ -44,7 +44,8 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          # Must match google-apps-scripts/package.json "packageManager" / lockfileVersion 9.
+          version: 10.16.0
 
       - name: Get pnpm store directory
         shell: bash

--- a/scripts/ci/get_python_version.py
+++ b/scripts/ci/get_python_version.py
@@ -4,32 +4,22 @@ import re
 import sys
 from pathlib import Path
 
-import sys
-from pathlib import Path
-
-# Add shared utilities to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent.parent / "shared_utilities"))
-from paths import get_repo_root
-
-project_root = get_repo_root()
-sys.path.insert(0, str(project_root))
-
-from scripts._shared.path_utils import PROJECT_ROOT
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def get_python_version() -> str:
     """Extract Python version from pyproject.toml."""
-    pyproject = PROJECT_ROOT / "pyproject.toml"
+    pyproject = _REPO_ROOT / "pyproject.toml"
     content = pyproject.read_text()
     match = re.search(r'requires-python\s*=\s*"([^"]+)"', content)
     if not match:
         raise RuntimeError("requires-python not found in pyproject.toml")
-    
+
     version_spec = match.group(1)
-    version_match = re.search(r'(\d+\.\d+)', version_spec)
+    version_match = re.search(r"(\d+\.\d+)", version_spec)
     if not version_match:
         raise RuntimeError(f"Could not parse version from requires-python: {version_spec}")
-    
+
     return version_match.group(1)
 
 

--- a/scripts/ci/install_dependencies.py
+++ b/scripts/ci/install_dependencies.py
@@ -8,30 +8,24 @@ import subprocess
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent.parent / "shared_utilities"))
-from paths import get_repo_root
-
-project_root = get_repo_root()
-sys.path.insert(0, str(project_root))
-
-from scripts._shared.path_utils import PROJECT_ROOT
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def install_backend_deps():
     """Install backend dependencies including dev dependencies for testing."""
-    backend_dir = PROJECT_ROOT / "backend"
+    backend_dir = _REPO_ROOT / "backend"
 
     subprocess.run(
         ["uv", "sync"],
         cwd=backend_dir,
         env={**os.environ, "UV_NO_PROGRESS": "1"},
-        check=True
+        check=True,
     )
 
     subprocess.run(
         ["uv", "tool", "install", "rich"],
         env={**os.environ, "UV_NO_PROGRESS": "1"},
-        check=True
+        check=True,
     )
 
 
@@ -40,22 +34,22 @@ def install_lambda_deps():
     subprocess.run(
         ["uv", "tool", "install", "pytest"],
         env={**os.environ, "UV_NO_PROGRESS": "1"},
-        check=True
+        check=True,
     )
     subprocess.run(
         ["uv", "tool", "install", "pytest-asyncio"],
         env={**os.environ, "UV_NO_PROGRESS": "1"},
-        check=True
+        check=True,
     )
     subprocess.run(
         ["uv", "tool", "install", "rich"],
         env={**os.environ, "UV_NO_PROGRESS": "1"},
-        check=True
+        check=True,
     )
     subprocess.run(
         ["uv", "tool", "install", "ruff==0.14.0"],
         env={**os.environ, "UV_NO_PROGRESS": "1"},
-        check=True
+        check=True,
     )
 
 
@@ -64,12 +58,12 @@ def install_deploy_deps():
     subprocess.run(
         ["uv", "tool", "install", "boto3"],
         env={**os.environ, "UV_NO_PROGRESS": "1"},
-        check=True
+        check=True,
     )
     subprocess.run(
         ["uv", "tool", "install", "requests"],
         env={**os.environ, "UV_NO_PROGRESS": "1"},
-        check=True
+        check=True,
     )
 
 

--- a/scripts/ci/run_script.py
+++ b/scripts/ci/run_script.py
@@ -3,14 +3,8 @@
 import sys
 from pathlib import Path
 
-# Add shared utilities to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent.parent / "shared_utilities"))
-from paths import get_repo_root
-
-project_root = get_repo_root()
-sys.path.insert(0, str(project_root))
-
-from scripts._shared.path_utils import PROJECT_ROOT
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT))
 
 if __name__ == "__main__":
     if len(sys.argv) < 3:
@@ -32,4 +26,3 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"❌ Error running function: {e}")
         sys.exit(1)
-

--- a/scripts/compilation/compile_main.py
+++ b/scripts/compilation/compile_main.py
@@ -12,8 +12,6 @@ from typing import Dict, List, Optional, Tuple
 from rich.console import Console
 from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn, TextColumn
 
-from scripts._shared.path_utils import PROJECT_ROOT
-
 from .repo_path_resolvers import (
     find_all_python_files,
     find_repo_root,
@@ -125,10 +123,9 @@ def get_src_root_for_file(file_path: Path, repo_root: Path) -> Path:
     
     if "backend" in parts:
         return abs_repo_root / "backend"
-    elif "lambda" in parts and "functions" in parts:
-        return abs_repo_root / "lambda" / "functions"
-    else:
-        return abs_repo_root
+    if "aws" in parts and "lambda" in parts and "functions" in parts:
+        return abs_repo_root / "aws" / "lambda" / "functions"
+    return abs_repo_root
 
 
 # ============================================================================
@@ -229,7 +226,8 @@ def run_all_checks(
     elif target_path == "backend":
         python_dirs = [repo_root / "backend"] if (repo_root / "backend").exists() else []
     elif target_path == "lambda":
-        python_dirs = [repo_root / "lambda" / "functions"] if (repo_root / "lambda" / "functions").exists() else []
+        fn_root = repo_root / "aws" / "lambda" / "functions"
+        python_dirs = [fn_root] if fn_root.exists() else []
     else:
         raise RuntimeError(f"Unknown target_path: {target_path}. Must be 'backend', 'lambda', or 'all'")
     
@@ -245,7 +243,7 @@ def run_all_checks(
         for file_path in files:
             if target_path == "backend" and "backend" in file_path.parts:
                 filtered_files.append(file_path)
-            elif target_path == "lambda" and "lambda" in file_path.parts and "functions" in file_path.parts:
+            elif target_path == "lambda" and "aws" in file_path.parts and "lambda" in file_path.parts and "functions" in file_path.parts:
                 filtered_files.append(file_path)
         files = filtered_files
     
@@ -339,7 +337,7 @@ def _compile_python_code(target_path: str) -> int:
     Returns:
         Exit code (0 for success, non-zero for failure)
     """
-    sys.path.insert(0, str(PROJECT_ROOT))
+    sys.path.insert(0, str(find_repo_root()))
     ensure_cli_paths_setup()
     
     try:
@@ -447,9 +445,10 @@ def _print_gas_errors(errors: List[str], phase: str) -> None:
 
 def compile_gas() -> int:
     """Compile Google Apps Scripts by running esbuild (catches syntax errors)."""
-    gas_root = PROJECT_ROOT / "google-apps-scripts"
+    repo = find_repo_root()
+    gas_root = repo / "google-apps-scripts"
     projects_dir = gas_root / "projects"
-    build_script = PROJECT_ROOT / "scripts" / "deployment" / "google" / "build.js"
+    build_script = repo / "scripts" / "deployment" / "google" / "build.js"
     
     if not projects_dir.exists():
         print(f"❌ GAS projects directory not found: {projects_dir}")

--- a/scripts/compilation/repo_path_resolvers.py
+++ b/scripts/compilation/repo_path_resolvers.py
@@ -1,20 +1,17 @@
 """Repository path resolution utilities for compilation checks."""
 
-import sys
 from pathlib import Path
 from typing import List
-
-import sys
-from pathlib import Path
-
-# Add shared utilities to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent.parent / "shared_utilities"))
-from paths import get_repo_root
 
 
 def find_repo_root() -> Path:
     """Find the repository root directory by looking for .git."""
-    return get_repo_root()
+    p = Path(__file__).resolve().parent
+    while p != p.parent:
+        if (p / ".git").exists():
+            return p
+        p = p.parent
+    raise RuntimeError("Could not find repository root (.git)")
 
 
 def find_all_python_files(repo_root: Path) -> List[Path]:
@@ -32,68 +29,62 @@ def find_all_python_files(repo_root: Path) -> List[Path]:
         candidate = repo_root / subpath
         if candidate.exists():
             python_files.extend(candidate.rglob("*.py"))
-    
-    # Filter out __pycache__ and test files if needed
+
     filtered = [
-        f for f in python_files
-        if "__pycache__" not in str(f)
-        and not f.name.startswith(".")
+        f
+        for f in python_files
+        if "__pycache__" not in str(f) and not f.name.startswith(".")
     ]
-    
+
     return sorted(filtered)
 
 
 def get_relative_path(file_path: Path, base_path: Path) -> str:
     """Get relative path from base_path to file_path as a string.
-    
+
     Args:
         file_path: Absolute or relative file path
         base_path: Base directory to compute relative path from
-        
+
     Returns:
         Relative path string (e.g., "backend/modules/auth.py")
     """
     try:
         return str(file_path.relative_to(base_path))
     except ValueError:
-        # If file_path is not relative to base_path, return the file name
         return file_path.name
 
 
 def path_to_module(file_path: Path, src_root: Path) -> str:
     """Convert a file path to a Python module name.
-    
+
     Args:
         file_path: Path to Python file
         src_root: Root directory (backend/ or aws/lambda/functions/)
 
     Returns:
-        Module name (e.g., "backend.modules.auth" or "ShopifyProductUpdates.main")
+        Module name (e.g., "backend.modules.auth" or "AwsRouter.main")
     """
     try:
         rel_path = file_path.relative_to(src_root)
-        # Remove .py extension and convert / to .
         module_name = str(rel_path.with_suffix("")).replace("/", ".")
-        # Remove __init__ suffix if present
         if module_name.endswith(".__init__"):
             module_name = module_name[:-9]
         elif module_name == "__init__":
-            # For __init__.py at root, use the directory name
             parent = src_root.name
             module_name = parent
         return module_name
     except ValueError:
-        # If not relative to src_root, try to infer from path
         parts = file_path.parts
         if "backend" in parts:
             idx = parts.index("backend")
-            module_parts = parts[idx + 1:]
-        elif "lambda" in parts and "functions" in parts:
-            idx = parts.index("lambda")
-            module_parts = parts[idx:]
+            module_parts = parts[idx + 1 :]
+        elif "aws" in parts and "lambda" in parts and "functions" in parts:
+            idx = parts.index("functions")
+            module_parts = parts[idx + 1 :]
         else:
             return file_path.stem
-        
+
         module_name = ".".join(p.stem if p.suffix == ".py" else p.name for p in [Path(p) for p in module_parts])
         if module_name.endswith(".__init__"):
             module_name = module_name[:-9]


### PR DESCRIPTION
- Trigger paths and deploy discovery use aws/lambda/functions; run pytest on aws/lambda/tests.
- Remove shared_utilities / path_utils bootstrap from CI helpers; resolve repo root locally.
- compile_main and repo_path_resolvers treat aws/lambda/functions as the Lambda source root.