### PR TITLE
Move lxml + beautifulsoup4 to dev dependencies

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,8 +29,6 @@ dependencies = [
     "python-box>=7.0.0",
 
     # Data Processing & Parsing
-    "beautifulsoup4==4.12.3",
-    "lxml==5.3.0", # for procesing html
     "PyYAML==6.0.2",
     "python-dotenv>=1.0.1",
     "python-dateutil>=2.9.0",
@@ -47,6 +45,8 @@ dependencies = [
 dev = [
     # Project-specific dev dependencies only
     # (monorepo-wide tools like ruff, pytest, mypy are in root pyproject.toml)
+    "beautifulsoup4==4.12.3",
+    "lxml==5.3.0",
 ]
 
 # Backend is not distributed as a wheel — it's consumed via local imports only.


### PR DESCRIPTION
Moves lxml and beautifulsoup4 from runtime to dev dependencies. These were only used by the legacy HTML-parsing refund engine which has been replaced by the metaobject-based approach. Unblocks CI (lxml fails to build without system libxml2-dev on the GH Actions runner).